### PR TITLE
Creates new webfonts library

### DIFF
--- a/components/base.css
+++ b/components/base.css
@@ -3,9 +3,6 @@
  * This is the base CSS file, for styling elements.
  */
 
-@import url('https://fonts.googleapis.com/css?family=Open+Sans');
-@import url('https://fonts.googleapis.com/css?family=Scope+One');
-
 /* Box Sizing all the things */
 html {
   box-sizing: border-box;

--- a/umami.info.yml
+++ b/umami.info.yml
@@ -5,6 +5,7 @@ description: 'The theme used for the out of the box initiative.'
 core: 8.x
 libraries:
   - umami/global
+  - umami/webfonts
 
 regions:
   top: Top

--- a/umami.libraries.yml
+++ b/umami.libraries.yml
@@ -11,6 +11,11 @@ global:
       styleguide/components/blocks/search/style.css: {}
       styleguide/components/navigation/menu--main/style.css: {}
 
+webfonts:
+  css:
+    theme:
+      'https://fonts.googleapis.com/css?family=Open+Sans|Scope+One': { type: external, minified: true }
+
 view-mode-highlighted-bottom:
   css:
     theme:


### PR DESCRIPTION
Removed webfonts imports from base.css and instead create new library for webfonts.
Webfonts library was appended to global theme library so webfonts are
available by default theme wide.