### PR TITLE
Ensure menutoggle behaviour is only applied once.

### DIFF
--- a/js/components/navigation/menu-main/menu-main.js
+++ b/js/components/navigation/menu-main/menu-main.js
@@ -7,7 +7,7 @@
   'use strict';
   Drupal.behaviors.menutoggle = {
     attach: function (context, settings) {
-      var toggler = $('[data-drupal-selector="menu-main__toggle"]');
+      var toggler = $('[data-drupal-selector="menu-main__toggle"]').once('menutoggle');
       var menu = $('[data-drupal-selector="menu-main"]');
 
       toggler.click(function toggle () {

--- a/umami.libraries.yml
+++ b/umami.libraries.yml
@@ -25,6 +25,7 @@ global:
     js/components/navigation/menu-main/menu-main.js: {}
   dependencies:
     - core/jquery
+    - core/jquery.once
 
 two-columns:
   css:


### PR DESCRIPTION
Fixes #143.

This PR uses jQuery.once() to ensure the menu button only gets one menutoggle click handler.

